### PR TITLE
🐛 Fixed flash of unstyled content appearing when toggling night mode

### DIFF
--- a/app/services/feature.js
+++ b/app/services/feature.js
@@ -126,11 +126,9 @@ export default Service.extend({
 
         return this.lazyLoader.loadStyle('dark', 'assets/ghost-dark.css', true).then(() => {
             $('link[title=dark]').prop('disabled', !nightShift);
-            $('link[title=light]').prop('disabled', nightShift);
         }).catch(() => {
             //TODO: Also disable toggle from settings and Labs hover
             $('link[title=dark]').prop('disabled', true);
-            $('link[title=light]').prop('disabled', false);
         });
     }
 });


### PR DESCRIPTION
closes #12396
We use two stylesheets ghost-light.css and ghost-dark.css for light mode and night mode respectively.
The problem occurs when we disable the light stylesheet when we enable dark stylesheet, as there is a moment when there is no style applied
This causes flash of unstyled content (or a big logo when users flip the night mode switch)

Since the ghost-dark style is loaded after the ghost-light stylesheet, we only need to enable or disable the dark stylesheet.
When the dark stylesheet is enabled, the light stylesheet will be overridden automatically by the browser.
I could not find any performance implications on overriding styles. The only performance implication is around loading a new stylesheet
which we already do.

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `ember test` from the repo root - will be `core/client` if working from the submodule in Ghost).

More info can be found by clicking the "guidelines for contributing" link above.
